### PR TITLE
style: remove trailing whitespace from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,7 +150,7 @@ Migrations/
 # Additional build artifacts
 *.AssemblyInfo.cs
 !Properties/AssemblyInfo.cs
-*.AssemblyInfoInputs.cache  
+*.AssemblyInfoInputs.cache
 *.csproj.AssemblyReference.cache
 .msCoverageSourceRootsMapping*
 *.Up2Date


### PR DESCRIPTION
- Remove trailing spaces from *.AssemblyInfoInputs.cache pattern
- Improve file formatting consistency