### PR TITLE
feat(db): create initial EF Core migration with database schema

### DIFF
--- a/WeaponApi.Domain/User/User.cs
+++ b/WeaponApi.Domain/User/User.cs
@@ -19,6 +19,13 @@ public sealed class User
 
     public IReadOnlyList<IDomainEvent> DomainEvents => domainEvents.AsReadOnly();
 
+    // Private parameterless constructor for Entity Framework
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor
+    private User()
+    {
+    }
+#pragma warning restore CS8618
+
     private User(UserId id, Email email, UserProfile profile, UserSecurity security, IReadOnlyList<Role> roles, DateTime createdAt)
     {
         Id = id;

--- a/WeaponApi.Domain/Weapon/Weapon.cs
+++ b/WeaponApi.Domain/Weapon/Weapon.cs
@@ -12,6 +12,13 @@ public class Weapon
   public bool IsRepairable { get; private set; }
   public decimal Value { get; private set; }
 
+  // Private parameterless constructor for Entity Framework
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor
+  private Weapon()
+  {
+  }
+#pragma warning restore CS8618
+
   private Weapon(WeaponId id, WeaponName name, string description, int hitPoints, int damage, bool isRepairable, decimal value)
   {
     Id = id;


### PR DESCRIPTION
- Add parameterless constructors to User and Weapon entities for EF Core compatibility
- Fix UserConfiguration index configuration for owned entities (Profile.Username)
- Add value comparer for Roles collection to resolve EF Core warning
- Generate InitialCreate migration with complete database schema:
  * users table with proper constraints and indexes
  * weapons table with business logic constraints
  * Check constraints for data validation (email format, positive values)
  * Unique indexes on email and username for performance
  * Performance indexes on commonly queried fields

Completes Phase 8 Step 1 of SETUP_INSTRUCTIONS.md - migration files ready for database creation